### PR TITLE
Fixed typo. Unified capitalization in shortcuts. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ class: home
         </div>
         <div class="minor-feature">
           <h2>File Structure</h2>
-          <p><kbd>Ctrl+F12</kbd> brings up an overview of the current file. It is usefull for navigation.
+          <p><kbd>Ctrl+F12</kbd> brings up an overview of the current file, useful for navigation.
             <kbd>Alt+7</kbd> presents the same information in the "project structure" style</p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ class: home
       <div class="major-feature">
         <h2>Native Code Completion <abbr title="Work In Progress" class="wip">WIP</abbr></h2>
         <p>intellij-rust features built from scratch code completion, leveraging IntelliJ Platform capabilities.
-          <kbd>Ctrl+space</kbd> invokes completion. A decent amount of completion intelligence is already
+          <kbd>Ctrl+Space</kbd> invokes completion. A decent amount of completion intelligence is already
           implemented, but it's still still at
           <a href="{{ site.github.url }}/docs/faq.html#whats-the-progress-on-code-completion">early stages</a>
           of development.
@@ -41,9 +41,9 @@ class: home
         <h2>Navigate Everywhere</h2>
         <ul>
           <li>Press <kbd>Ctrl+B</kbd> to jump to definition</li>
-          <li><kbd>Ctrl+n</kbd> finds any struct or enum by name</li>
+          <li><kbd>Ctrl+N</kbd> finds any struct or enum by name</li>
           <li><kbd>Ctrl+Alt+Shift+N</kbd> finds any symbol (functions, traits, modules, methods, fields) by name</li>
-          <li><kbd>Ctrl+u</kbd> brings you to the parent of the current module</li>
+          <li><kbd>Ctrl+U</kbd> brings you to the parent of the current module</li>
         </ul>
       </div>
     </div>
@@ -52,7 +52,7 @@ class: home
       <div class="minor-feature col-1-3 stack">
         <div class="minor-feature">
           <h2>Code Formatter</h2>
-          <p><kbd>Ctrl+Alt+l</kbd> reformats current file using our custom, fully functional
+          <p><kbd>Ctrl+Alt+L</kbd> reformats current file using our custom, fully functional
             formatter based on IntelliJ's formatting engine, though <code>rustfmt</code> support
             is <abbr title="Work In Progress" class="wip">WIP</abbr></p>
         </div>
@@ -101,7 +101,7 @@ class: home
       </div>
       <div class="minor-feature col-1-3">
         <h2>Quick Documentation</h2>
-        <p><kbd>Ctrl+q</kbd> shows docs for the thing at caret</p>
+        <p><kbd>Ctrl+Q</kbd> shows docs for the thing at caret</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Feel free to disregard the capitalization if there was a deeper logic to it. I just thought it looks nicer if all commands are either shown lower or upper case (picked upper case). 