### PR TITLE
Switch quick-start gif to a video

### DIFF
--- a/_docs/quick-start.markdown
+++ b/_docs/quick-start.markdown
@@ -53,4 +53,4 @@ Check that the basic functionality is working. Try **Goto Symbol**
 completion <kbd>Ctrl+Space</kbd>.
 
 
-{% include feature-gfy.html n="SadCourteousDobermanpinscher" %}
+{% include feature-video.html v="quick-start/features" %}

--- a/_includes/feature-video.html
+++ b/_includes/feature-video.html
@@ -1,0 +1,5 @@
+<div class="video">
+  <video controls>
+    <source src="/assets/{{ include.v }}.webm" type="video/webm">
+  </video>
+</div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -52,6 +52,15 @@ img {
 }
 
 
+/**
+ * Videos
+ */
+video {
+    max-width: 100%;
+    vertical-align: middle;
+}
+
+
 
 /**
  * Figures


### PR DESCRIPTION
Looks like GIFs stopped working for some reason.

Let's switch to the videos instead? Hopefully, everyone can play webm now...

6.4 mb seems a little big for me, but it'll be loaded on demand, and I don't think we should worry about the repo size here

cc @vlad20012 