### PR TITLE
Fix list (of changes) layout in changelog

### DIFF
--- a/changelog.py
+++ b/changelog.py
@@ -33,11 +33,11 @@ class ChangelogItem:
 
     def display(self):
         if self.username in MAINTAINERS:
-            return "<!-- https://github.com/intellij-rust/intellij-rust/pull/{} -->\n* {}"\
-                .format(self.pull_request_id, self.description)
+            return "* {}\n  <!-- https://github.com/intellij-rust/intellij-rust/pull/{} -->"\
+                .format(self.description, self.pull_request_id)
         else:
-            return "<!-- https://github.com/intellij-rust/intellij-rust/pull/{} -->\n* {} (by [@{}])"\
-                .format(self.pull_request_id, self.description, self.username)
+            return "* {} (by [@{}])\n  <!-- https://github.com/intellij-rust/intellij-rust/pull/{} -->"\
+                .format(self.description, self.username, self.pull_request_id)
 
 
 class ChangelogSection(object):


### PR DESCRIPTION
Currently we generate changelog items like this:
```
<!-- https://github.com/intellij-rust/intellij-rust/pull/1234 -->
* The first change

<!-- https://github.com/intellij-rust/intellij-rust/pull/5678 -->
* The second change
```

This produces incorrect HTML where each list item is wrapped into
new `<ul>` tag:

```
<ul>
    <li>The first change</li>
</ul>
<ul>
    <li>The second change</li>
</ul>
```

I modified `changelog.py` so that now it places comments with PR
links after a list item, not before it:

```
* The first change
  <!-- https://github.com/intellij-rust/intellij-rust/pull/1234 -->

* The second change
  <!-- https://github.com/intellij-rust/intellij-rust/pull/5678 -->
```

Such positioning of comments fixes the issue with HTML:

```
<ul>
    <li>The first change</li>
    <li>The second change</li>
</ul>
```