### PR TITLE
Make `changelog.py` compatible with python 3.8

### DIFF
--- a/changelog.py
+++ b/changelog.py
@@ -274,7 +274,7 @@ def contributor_list(args: argparse.Namespace) -> None:
         print(c)
 
 
-def collect_contributors(repo: Repository, milestone: Milestone) -> set[str]:
+def collect_contributors(repo: Repository, milestone: Milestone) -> Set[str]:
     milestone_contributors = set()
     issues = repo.get_issues(milestone=milestone, state="all")
     for issue in issues:


### PR DESCRIPTION
In https://github.com/intellij-rust/intellij-rust/pull/9584 we want to use preinstalled python on GitHub runners. And currently python 3.8 is default version for Ubuntu 20.04. Since `changelog.py` is a part of `create changelog` workflow, we need to be compatible with python 3.8 here as well